### PR TITLE
Keep on sending log to remote server, even if the log rotates.

### DIFF
--- a/src/netlog-manager.c
+++ b/src/netlog-manager.c
@@ -231,6 +231,7 @@ static int process_journal_input(Manager *m) {
 
                 r = manager_read_journal_input(m);
                 if (r < 0) {
+                        m->current_cursor = mfree(m->current_cursor);
                         /* Can't send the message. Seek one entry back. */
                         r = sd_journal_previous(m->journal);
                         if (r < 0)


### PR DESCRIPTION
systemd-netlogd stops sending log data to remote server, when the limits on the journal log files size is reach and the log is rotated, by clean ups.