### PR TITLE
Fix syslog header truncation

### DIFF
--- a/src/netlog-network.c
+++ b/src/netlog-network.c
@@ -113,9 +113,9 @@ int manager_push_to_network(Manager *m,
                             const char *hostname,
                             const char *pid,
                             const struct timeval *tv) {
-        char header_priority[sizeof("< >1 ") + 1];
+        char header_priority[sizeof("<   >1 ")];
         char header_time[FORMAT_TIMESTAMP_MAX];
-        uint16_t makepri;
+        uint8_t makepri;
         struct iovec iov[13];
         int n = 0;
 


### PR DESCRIPTION
The priority value in the syslog header is between 0 (one digit) and 191
(three digits). The call to snprintf() might have cut off the whitespace
before the timestamp field of the header for priority values greater
than 99.