### PR TITLE
units: update ExecStart path for improved portability

### DIFF
--- a/units/systemd-netlogd.service.in
+++ b/units/systemd-netlogd.service.in
@@ -11,7 +11,7 @@ Documentation=man:systemd-netlogd.conf(5)
 After=network.target
 
 [Service]
-ExecStart=/usr/lib/systemd/systemd-netlogd
+ExecStart=/lib/systemd/systemd-netlogd
 PrivateTmp=yes
 PrivateDevices=yes
 WatchdogSec=20min


### PR DESCRIPTION
On Fedora 28, /lib is a symlink to /usr/lib. On Ubuntu 18.04 LTS, the two are independent directories.  Furthermore, on Ubuntu 18.04 LTS, all the systemd-* binaries live in /lib/systemd/, not /usr/lib/systemd/.

This changes the ExecStart line to /lib/systemd/systemd-netlogd to improve portability across different Linux distributions.  Closes #11.