### PR TITLE
process_journal_input(): workaround EADDRNOTAVAIL after journal rotation

### DIFF
--- a/src/netlog-manager.h
+++ b/src/netlog-manager.h
@@ -37,7 +37,7 @@ struct Manager {
 
         char *state_file;
 
-        char *last_cursor, *current_cursor;
+        char *last_cursor;
         char *structured_data;
 };
 


### PR DESCRIPTION
A workaround for issue #14 