### PR TITLE
Reset the cursor if it sd_journal_get_cursor fails

### DIFF
--- a/src/netlog-manager.c
+++ b/src/netlog-manager.c
@@ -228,8 +228,10 @@ static int process_journal_input(Manager *m) {
         }
 
         r = sd_journal_get_cursor(m->journal, &m->current_cursor);
-        if (r < 0)
-                return log_error_errno(r, "Failed to get cursor: %m");
+        if (r < 0) {
+                log_error_errno(r, "Failed to get cursor: %m");
+                m->current_cursor = mfree(m->current_cursor);
+        }
 
         free(m->last_cursor);
         m->last_cursor = m->current_cursor;


### PR DESCRIPTION
~~~
Jun 22 21:15:09 node1.pi-jaas-kube1.kubernetes.cluster.int systemd[1]: Started systemd-netlogd.service.
Jun 23 08:10:43 node1.pi-jaas-kube1.kubernetes.cluster.int systemd-netlogd[18915]: Failed to get cursor: Cannot assign requested address
~~~

Closes #17