### PR TITLE
remove hard-coding /lib/systemd  , for build archlinux package

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ conf.set_quoted('PACKAGE_STRING',  meson.project_name() + ' ' + meson.project_ve
 substs = configuration_data()
 substs.set('PACKAGE_URL',          'https://github.com/systemd/systemd-netlogd')
 substs.set('PACKAGE_VERSION',      meson.project_version())
+substs.set('PKGPREFIX',   get_option('prefix'))
 conf.set_quoted('PKGSYSCONFDIR',   get_option('sysconfdir'))
 
 #####################################################################
@@ -166,4 +167,4 @@ systemd_netlogd = executable(
                    libcap,
                    libsystemd],
                    install : true,
-                   install_dir : '/lib/systemd')
+                   install_dir : get_option('prefix'))

--- a/units/systemd-netlogd.service.in
+++ b/units/systemd-netlogd.service.in
@@ -7,7 +7,7 @@ Documentation=man:systemd-netlogd.conf(5)
 After=network.target
 
 [Service]
-ExecStart=/lib/systemd/systemd-netlogd
+ExecStart=@PKGPREFIX@/systemd-netlogd
 PrivateTmp=yes
 PrivateDevices=yes
 WatchdogSec=20min


### PR DESCRIPTION
archlinux keep  /lib/  own by filesystem , pkg shuould not install under /lib

this pr remove hardcoding  `/lib/systemd`  in   `.service` file and meson build scripts , and using  PKGPREFIX='/lib/systemd/' as default ,  

```
Directory Symlink Handling: Example time! Arch Linux has a /lib -> /usr/lib symlink. Previously, if pacman was installing a package and it found files in /lib, it would follow the symlink and install it in /usr/lib. However the filelist for that package still recorded the file in /lib. This caused heaps of difficulty in conflict resolving – primarily the need to resolve every path of all package files to look for conflicts. That was a stupid idea! So now if pacman sees a /lib directory in a package, it will detect a conflict with the symlink on the filesystem. If you were using this feature to install files elsewhere, you probably need to look into what a bind mount is! Note that this change requires us to correct the local package file list for any package installed using this mis-feature, so we bumped the database version. Upgrade using pacman-db-upgrade. Thanks to Andrew!
```
ref  http://allanmcrae.com/2014/12/pacman-4-2-released/