### PR TITLE
Support dynamic STRUCTURED-DATA and MSGID

### DIFF
--- a/src/netlog/netlog-manager.h
+++ b/src/netlog/netlog-manager.h
@@ -57,6 +57,7 @@ int manager_open_network_socket(Manager *m);
 int manager_push_to_network(Manager *m, int severity, int facility,
                             const char *identifier, const char *message,
                             const char *hostname, const char *pid,
+                            const char *structured_data, const char *msgid,
                             const struct timeval *tv);
 
 const char *protocol_to_string(int v) _const_;

--- a/src/netlog/netlog-network.c
+++ b/src/netlog/netlog-network.c
@@ -94,6 +94,8 @@ int manager_push_to_network(Manager *m,
                             const char *message,
                             const char *hostname,
                             const char *pid,
+                            const char *structured_data,
+                            const char *msgid,
                             const struct timeval *tv) {
         char header_priority[sizeof("<   >1 ")];
         char header_time[FORMAT_TIMESTAMP_MAX];
@@ -139,13 +141,19 @@ int manager_push_to_network(Manager *m,
         IOVEC_SET_STRING(iov[n++], " ");
 
         /* Seventh: msgid */
-        IOVEC_SET_STRING(iov[n++], RFC_5424_NILVALUE);
+        if (msgid)
+                IOVEC_SET_STRING(iov[n++], msgid);
+        else
+                IOVEC_SET_STRING(iov[n++], RFC_5424_NILVALUE);
+
         IOVEC_SET_STRING(iov[n++], " ");
 
         /* Eighth: [structured-data] */
         if (m->structured_data)
                 IOVEC_SET_STRING(iov[n++], m->structured_data);
-        else
+        if (structured_data)
+                IOVEC_SET_STRING(iov[n++], structured_data);
+        if (!(m->structured_data || structured_data))
                 IOVEC_SET_STRING(iov[n++], RFC_5424_NILVALUE);
 
         IOVEC_SET_STRING(iov[n++], " ");


### PR DESCRIPTION
### Read RFC 5424 structured data and MSGID from journal entries, and add them to the syslog frame.
Usage: write a journal entry containing the fields `SYSLOG_STRUCTURED_DATA` and `SYSLOG_MSGID`, and those fields will be forwarded by systemd-netlogd.
Example:

```
  sd_journal_send(
    "MESSAGE=%s", "Message to process",
    "PRIORITY=%s", "4",
    "SYSLOG_FACILITY=%s", "1",
    "SYSLOG_MSGID=%s", "1011",
    "SYSLOG_STRUCTURED_DATA=%s", R"([exampleSDID@32473 iut="3" eventSource="Application"])",
    nullptr // nullptr terminates the parameter list
  );
```
The above example results in the following syslog frame:
`<12>1 2024-02-09T08:50:14.406197+01:00 d11 journalExport 10932 1011 [exampleSDID@32473 iut="3" eventSource="Application"] Message to process`
If we combine this with e.g. `StructuredData=[a@32473]` in /etc/systemd/systemd-netlogd.conf, then that is prepended to the structured data found in journal entries, e.g.:
`<12>1 2024-02-09T08:50:14.406197+01:00 d11 journalExport 10932 1011 [a@32473][exampleSDID@32473 iut="3" eventSource="Application"] Message to process`

Please note that the configured `StructuredData` is copied literally, and if it has a trailing space, structured data from the journal ends up in the message part of the syslog frame.