### PR TITLE
Update prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('systemd-netlogd', 'c',
         license : 'LGPLv2+',
         default_options: [
                 'c_std=gnu11',
-                'prefix=/lib/systemd',
+                'prefix=/usr/lib/systemd',
                 'sysconfdir=/etc/systemd',
                 'localstatedir=/var',
                 'warning_level=2',


### PR DESCRIPTION
Since systemd requires a usr-merged system update the prefix to /usr/lib/systemd.