### PR TITLE
dtls: Fix crash when connection fails

### DIFF
--- a/src/netlog/netlog-dtls.c
+++ b/src/netlog/netlog-dtls.c
@@ -120,7 +120,8 @@ int dtls_connect(DTLSManager *m, SocketAddress *address) {
                                        "Failed to allocate memory for bio: %m");
 
         BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_CONNECTED, 0, &address);
-        SSL_set_bio(ssl , bio, bio);
+        SSL_set_bio(ssl, bio, bio);
+        m->bio = TAKE_PTR(bio);
 
         /* Cerification verification  */
         if (m->auth_mode != OPEN_SSL_CERTIFICATE_AUTH_MODE_NONE && m->auth_mode != OPEN_SSL_CERTIFICATE_AUTH_MODE_INVALID) {
@@ -163,7 +164,6 @@ int dtls_connect(DTLSManager *m, SocketAddress *address) {
         /* Set and activate timeouts */
         BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_RECV_TIMEOUT, 0, &timeout);
 
-        m->bio = TAKE_PTR(bio);
         m->ssl = TAKE_PTR(ssl);
         m->ctx = ctx;
         m->fd = fd;


### PR DESCRIPTION
```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Failed to SSL_connect: error:00000000:lib(0)::reason(0)

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7a78911 in BIO_free () from /lib64/libcrypto.so.3
Missing debuginfo, try: dnf debuginfo-install libcap-2.69-8.fc41.x86_64
Missing debuginfo, try: dnf debuginfo-install openssl-libs-3.2.1-6.fc41.x86_64
Missing debuginfo, try: dnf debuginfo-install systemd-libs-256~rc2-1.fc41.x86_64
Missing debuginfo, try: dnf debuginfo-install glibc-2.39.9000-18.fc41.x86_64
Missing debuginfo, try: dnf debuginfo-install zlib-ng-compat-2.1.6-3.fc41.x86_64
Missing debuginfo, try: dnf debuginfo-install libgcc-14.1.1-1.fc41.x86_64
(gdb) bt

```