### PR TITLE
Use SPDX license expression and correct version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('systemd-netlogd', 'c',
         version : '1.4.1',
-        license : 'LGPLv2+',
+        license : 'LGPL-2.1-or-later',
         default_options: [
                 'c_std=gnu11',
                 'prefix=/usr/lib/systemd',


### PR DESCRIPTION
According to the meson documentation[1] the license value should be a SPDX license expression.
Also use the LGPL version 2.1 as stated by the SPDX-License-Identifier headers in the source files.

[1]: https://mesonbuild.com/Reference-manual_functions.html#project