### PR TITLE
Simplify socket address length usage

### DIFF
--- a/src/netlog/netlog-dtls.c
+++ b/src/netlog/netlog-dtls.c
@@ -55,7 +55,6 @@ int dtls_connect(DTLSManager *m, SocketAddress *address) {
         _cleanup_(SSL_freep) SSL *ssl = NULL;
         _cleanup_free_ char *pretty = NULL;
         const SSL_CIPHER *cipher;
-        union sockaddr_union sa;
         socklen_t salen;
         SSL_CTX *ctx;
         struct timeval timeout = {
@@ -69,20 +68,10 @@ int dtls_connect(DTLSManager *m, SocketAddress *address) {
 
         switch (address->sockaddr.sa.sa_family) {
                 case AF_INET:
-                        sa = (union sockaddr_union) {
-                                .in.sin_family = address->sockaddr.sa.sa_family,
-                                .in.sin_port = address->sockaddr.in.sin_port,
-                                .in.sin_addr = address->sockaddr.in.sin_addr,
-                        };
-                        salen = sizeof(sa.in);
+                        salen = sizeof(address->sockaddr.in);
                         break;
                 case AF_INET6:
-                        sa = (union sockaddr_union) {
-                                .in6.sin6_family = address->sockaddr.sa.sa_family,
-                                .in6.sin6_port = address->sockaddr.in6.sin6_port,
-                                .in6.sin6_addr = address->sockaddr.in6.sin6_addr,
-                        };
-                        salen = sizeof(sa.in6);
+                        salen = sizeof(address->sockaddr.in6);
                         break;
                 default:
                         return -EAFNOSUPPORT;

--- a/src/netlog/netlog-network.c
+++ b/src/netlog/netlog-network.c
@@ -138,7 +138,6 @@ void manager_close_network_socket(Manager *m) {
 
 int manager_network_connect_socket(Manager *m) {
         _cleanup_free_ char *pretty = NULL;
-        union sockaddr_union sa;
         const char *protocol;
         socklen_t salen;
         int r;
@@ -148,20 +147,10 @@ int manager_network_connect_socket(Manager *m) {
 
         switch (m->address.sockaddr.sa.sa_family) {
                 case AF_INET:
-                        sa = (union sockaddr_union) {
-                                .in.sin_family = m->address.sockaddr.sa.sa_family,
-                                .in.sin_port = m->address.sockaddr.in.sin_port,
-                                .in.sin_addr = m->address.sockaddr.in.sin_addr,
-                        };
-                        salen = sizeof(sa.in);
+                        salen = sizeof(m->address.sockaddr.in);
                         break;
                 case AF_INET6:
-                        sa = (union sockaddr_union) {
-                                .in6.sin6_family = m->address.sockaddr.sa.sa_family,
-                                .in6.sin6_port = m->address.sockaddr.in6.sin6_port,
-                                .in6.sin6_addr = m->address.sockaddr.in6.sin6_addr,
-                        };
-                        salen = sizeof(sa.in6);
+                        salen = sizeof(m->address.sockaddr.in6);
                         break;
                 default:
                         return -EAFNOSUPPORT;

--- a/src/netlog/netlog-tls.c
+++ b/src/netlog/netlog-tls.c
@@ -164,7 +164,6 @@ int tls_connect(TLSManager *m, SocketAddress *address) {
         _cleanup_(SSL_freep) SSL *ssl = NULL;
         _cleanup_free_ char *pretty = NULL;
         const SSL_CIPHER *cipher;
-        union sockaddr_union sa;
         socklen_t salen;
         SSL_CTX *ctx;
         int fd, r;
@@ -174,20 +173,10 @@ int tls_connect(TLSManager *m, SocketAddress *address) {
 
         switch (address->sockaddr.sa.sa_family) {
                 case AF_INET:
-                        sa = (union sockaddr_union) {
-                                .in.sin_family = address->sockaddr.sa.sa_family,
-                                .in.sin_port = address->sockaddr.in.sin_port,
-                                .in.sin_addr = address->sockaddr.in.sin_addr,
-                        };
-                        salen = sizeof(sa.in);
+                        salen = sizeof(address->sockaddr.in);
                         break;
                 case AF_INET6:
-                        sa = (union sockaddr_union) {
-                                .in6.sin6_family = address->sockaddr.sa.sa_family,
-                                .in6.sin6_port = address->sockaddr.in6.sin6_port,
-                                .in6.sin6_addr = address->sockaddr.in6.sin6_addr,
-                        };
-                        salen = sizeof(sa.in6);
+                        salen = sizeof(address->sockaddr.in6);
                         break;
                 default:
                         return -EAFNOSUPPORT;


### PR DESCRIPTION
Drop unnecessary usage of an unused local variable and calculate the size via the already available address union member.

Closes: #118 