### PR TITLE
Fix build on 32-bit with 64-bit time_t

### DIFF
--- a/src/netlog/netlog-protocol.c
+++ b/src/netlog/netlog-protocol.c
@@ -69,7 +69,7 @@ void format_rfc3339_timestamp(const struct timeval *tv, char *header_time, size_
 
         /* add fractional part */
         if (tv) {
-                r = snprintf(header_time, header_size, ".%06ld", tv->tv_usec);
+                r = snprintf(header_time, header_size, ".%06lld", (long long)tv->tv_usec);
                 assert(r > 0 && (size_t)r < header_size);
                 header_time += r;
                 header_size -= r;


### PR DESCRIPTION
gcc reports:

    ../src/netlog/netlog-protocol.c: In function ‘format_rfc3339_timestamp’:
    ../src/netlog/netlog-protocol.c:72:62: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘__suseconds64_t’ {aka ‘long long int’} [-Werror=format=]
       72 |                 r = snprintf(header_time, header_size, ".%06ld", tv->tv_usec);
          |                                                          ~~~~^   ~~~~~~~~~~~
          |                                                              |     |
          |                                                              |     __suseconds64_t {aka long long int}
          |                                                              long int
          |                                                          %06lld