### PR TITLE
Add RFC5425 length field

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ systemd-netlogd reads configuration files named `/etc/systemd/netlogd.conf` and 
         Specifies whether to use udp, tcp, tls or dtls (Datagram Transport Layer Security) protocol. Defaults to udp.
 
     LogFormat=
-        Specifies whether to use RFC 5424 format or RFC 3339 format. Takes one of rfc5424 or rfc3339. Defaults to rfc5424.
+        Specifies whether to use RFC 5424, RFC 5425, or RFC 3339 format. Takes one of rfc5424, rfc5425, or rfc3339. Defaults to rfc5424. RFC 5425 is mainly useful for sending over TLS; it prepends a message length field to the RFC 5424 format.
 
     Directory=
         Takes a directory path. Specifies whether to operate on the specified journal directory DIR instead of the default runtime and system journal paths.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,7 +34,7 @@ This will create a user systemd-journal-netlog
         Specifies whether to use udp, tcp, tls or dtls (Datagram Transport Layer Security) protocol. Defaults to udp.
 
 | ``LogFormat=``
-        Specifies whether to use RFC 5424 format or RFC 3339 format. Takes one of rfc5424 or rfc3339. Defaults to rfc5424.
+        Specifies whether to use RFC 5424, RFC 5425, or RFC 3339 format. Takes one of rfc5424, rfc5425, or rfc3339. Defaults to rfc5424. RFC 5425 is mainly useful for sending over TLS; it prepends a message length field to the RFC 5424 format.
 
 | ``Directory=``
         Takes a directory path. Specifies whether to operate on the specified journal directory DIR instead of the default runtime and system journal paths.

--- a/src/netlog/netlog-manager.c
+++ b/src/netlog/netlog-manager.c
@@ -39,6 +39,7 @@ DEFINE_STRING_TABLE_LOOKUP(protocol, SysLogTransmissionProtocol);
 
 static const char *const log_format_table[_SYSLOG_TRANSMISSION_LOG_FORMAT_MAX] = {
         [SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5424] = "rfc5424",
+        [SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5425] = "rfc5425",
         [SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_3339] = "rfc3339",
 };
 

--- a/src/netlog/netlog-manager.h
+++ b/src/netlog/netlog-manager.h
@@ -25,6 +25,7 @@ typedef enum SysLogTransmissionProtocol {
 typedef enum SysLogTransmissionLogFormat {
         SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5424      = 1 << 0,
         SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_3339      = 1 << 1,
+        SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5425      = 1 << 2,
         _SYSLOG_TRANSMISSION_LOG_FORMAT_MAX,
         _SYSLOG_TRANSMISSION_LOG_FORMAT_INVALID = -EINVAL,
 } SysLogTransmissionLogFormat;

--- a/src/netlog/netlog-network.c
+++ b/src/netlog/netlog-network.c
@@ -112,7 +112,7 @@ int manager_push_to_network(Manager *m,
                         break;
         }
 
-        if (m->log_format == SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5424)
+        if (m->log_format == SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5424 || m->log_format == SYSLOG_TRANSMISSION_LOG_FORMAT_RFC_5425)
                r = format_rfc5424(m, severity, facility, identifier, message, hostname, pid, tv, syslog_structured_data, syslog_msgid);
         else
                r = format_rfc3339(m, severity, facility, identifier, message, hostname, pid, tv);


### PR DESCRIPTION
Add a `LogFormat` to pick framing the message with an RFC 5425 length field. The RFC doesn't specify a maximum length, but does suggest 8192; added a digit over that to make sure systemd-netlogd is not the limit. This is an alternative to the newline framing, and can also be used over plain TCP (non-TLS), e.g., RFC 6587.

This isn't full RFC 5425 support as this patch doesn't add support for client certificates.

PS: I extended the `SysLogTransmissionLogFormat` table the way you currently have it, which uses powers-of-two like a bit mask (as if you could set multiple of them). I didn't actually see it used like that in the code though, so I'm not sure why it and `SysLogTransmissionProtocol` are done that way. I think that's wasting some space in in the `log_format_table` and `protocol_table` (currently an insignificant amount, but doubling each new flag) but otherwise doesn't matter.