### PR TITLE
Fix const-correctness for pointer variables to referred strings

### DIFF
--- a/src/netlog/netlog-conf.c
+++ b/src/netlog/netlog-conf.c
@@ -22,7 +22,7 @@ int config_parse_netlog_remote_address(const char *unit,
                                        void *data,
                                        void *userdata) {
         Manager *m = userdata;
-        char *e;
+        const char *e;
         int r;
 
         assert(filename);

--- a/src/share/path-util.c
+++ b/src/share/path-util.c
@@ -327,7 +327,8 @@ bool path_is_safe(const char *p) {
 }
 
 char *file_in_same_dir(const char *path, const char *filename) {
-        char *e, *ret;
+        const char *e;
+        char *ret;
         size_t k;
 
         assert(path);

--- a/src/share/socket-util.c
+++ b/src/share/socket-util.c
@@ -33,7 +33,8 @@
 #include "util.h"
 
 int socket_address_parse(SocketAddress *a, const char *s) {
-        char *e, *n;
+        const char *e;
+        char *n;
         unsigned u;
         int r;
 


### PR DESCRIPTION
Mark pointer variables 'e' as 'const char *' in
config_parse_netlog_remote_address,file_in_same_dir, and socket_address_parse, since they point to memory they do not own or modify.

## Summary

Brief description of the changes.

Fixes #(issue number)

## Changes

-
-

## Testing

- [x] `meson test -C build` passes
- [ ] Tested with UDP/TCP/TLS as applicable
- [ ] New code has test coverage (if applicable)

## Checklist

- [ ] Code follows systemd coding style
- [ ] Commit messages are clear and descriptive
- [ ] Documentation updated (if applicable)
- [ ] No new compiler warnings
